### PR TITLE
Fix transfer process not always cleanly ending

### DIFF
--- a/bin.src/dbb_save_ats_raw.py
+++ b/bin.src/dbb_save_ats_raw.py
@@ -330,6 +330,14 @@ def save_file(filename, common_info, trans_opts, dryrun):
                             tar.addfile(afile["tarinfo"], afile["data"])
                         else:
                             tar.add(afile["filename"], arcname=afile["arcname"])
+
+                # Explicit close to address problems in https://jira.lsstcorp.org/browse/DM-16181
+                process_trans.stdin.close()
+                logging.debug("Tar done, waiting for curl to end")
+                process_trans.wait()
+                logging.debug("process_trans.returncode = %s" % process_trans.returncode)
+                if process_trans.returncode != 0:
+                    raise RuntimeError("Non-zero transfer returncode (%s)" % process_trans.returncode)
             except:
                 out = process_trans.communicate()[0].decode("utf-8")
                 if process_trans.returncode != 0:


### PR DESCRIPTION
Files in delivery area on NCSA gateway machine were there as temp files but
then disappeared instead of being renamed real filename.  Further debugging
discovered that curl subprocess was not itself always ending but the code
moved on and Python garbage collection cleaned it up.   When the tarfile
close occurred, it did not seem to close the subprocess pipe it was using
for output.